### PR TITLE
Fix readback clip batch reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           dotnet build tests/Goo.FailedIdleSmoke/Goo.FailedIdleSmoke.gsproj \
             -c Release -p:TreatWarningsAsErrors=true \
             -p:GooLinuxSdlPath="$PWD/artifacts/native/libSDL3.so"
+          dotnet build tests/Goo.AsyncReadbackSmoke/Goo.AsyncReadbackSmoke.gsproj \
+            -c Release -p:TreatWarningsAsErrors=true \
+            -p:GooLinuxSdlPath="$PWD/artifacts/native/libSDL3.so"
 
       - name: Run portable Vulkan checks
         run: |
@@ -102,6 +105,11 @@ jobs:
           run_vulkan_proof_lane GOO_VK_TEXT_PAINT_E2E
           run_vulkan_proof_lane GOO_VK_TEXT_EFFECT_READBACK
           run_vulkan_proof_lane GOO_VK_TEXT_PAINT_READBACK
+
+          .github/scripts/with-headless-wayland.sh env \
+            GOO_VK_DIAGNOSTICS=1 \
+            GOO_CLIP_CAPTURE_SMOKE=1 \
+            dotnet tests/Goo.AsyncReadbackSmoke/bin/Release/net10.0/Goo.AsyncReadbackSmoke.dll
 
       - name: Record dependencies and reject known vulnerabilities
         run: |

--- a/Goo/Rendering/Vulkan/VulkanAsyncReadback.gs
+++ b/Goo/Rendering/Vulkan/VulkanAsyncReadback.gs
@@ -24,6 +24,14 @@ internal unsafe sealed class VulkanAsyncReadback : IDisposable {
   internal prop Extent VkExtent2D{ get { return target.Extent } }
   internal prop Region VulkanReadbackRegion{ get { return region } }
   internal prop IsPending bool{ get { return state == VulkanReadbackState.Pending } }
+  internal prop SubmissionPendingReconcile bool{
+    get -> state == VulkanReadbackState.Pending
+      && target.SubmissionPendingReconcile
+  }
+  internal prop SubmissionReadyForReconcile bool{
+    get -> state == VulkanReadbackState.Pending
+      && target.SubmissionReadyForReconcile
+  }
   internal prop TargetPending bool{
     get { return state == VulkanReadbackState.Pending || target.State == VulkanOffscreenState.Pending }
   }

--- a/Goo/Rendering/Vulkan/VulkanOffscreenTarget.gs
+++ b/Goo/Rendering/Vulkan/VulkanOffscreenTarget.gs
@@ -98,6 +98,11 @@ internal unsafe sealed class VulkanOffscreenTarget : IDisposable {
   internal prop ResourceGeneration uint64{ get { return resourceGeneration } }
   internal prop ClipMaskAtlas VulkanClipMaskAtlas{ get { return clipMaskAtlas } }
   internal prop State VulkanOffscreenState{ get { return state } }
+  internal prop SubmissionPendingReconcile bool{ get -> queuePending }
+  internal prop SubmissionReadyForReconcile bool{
+    get -> queuePending
+      && queueMailbox.Phase == VulkanQueueMailboxPhase.SubmitComplete
+  }
   internal prop LastResult VkResult{ get { return lastResult } }
   internal prop DeviceLossDetected bool{
     get {

--- a/Goo/Rendering/Vulkan/VulkanWindowTarget.Core.gs
+++ b/Goo/Rendering/Vulkan/VulkanWindowTarget.Core.gs
@@ -334,6 +334,9 @@ internal unsafe partial class VulkanWindowTarget : IDisposable, FrameProfileSink
       }
     }
     VulkanDeviceRecoveryCoordinator.ServiceQueueCompletions(this)
+    if DeferForPendingReadbackSubmission() {
+      return
+    }
     if let activeRuntime = runtime {
       if activeRuntime.DeviceLost || activeRuntime.Terminal {
         presentationRetirement.ClearPresentationLatency()

--- a/Goo/Rendering/Vulkan/VulkanWindowTarget.Readback.gs
+++ b/Goo/Rendering/Vulkan/VulkanWindowTarget.Readback.gs
@@ -23,6 +23,26 @@ internal unsafe partial class VulkanWindowTarget {
     get { return readbackRequest?.IsPending == true }
   }
 
+  internal prop ReadbackSubmissionReadyForReconcile bool{
+    get -> readbackRequest?.SubmissionReadyForReconcile == true
+  }
+
+  private func DeferForPendingReadbackSubmission() bool {
+    guard let request = readbackRequest else {
+      return false
+    }
+    if !request.SubmissionPendingReconcile {
+      return false
+    }
+    PollReadback()
+    if readbackRequest?.SubmissionPendingReconcile != true {
+      return false
+    }
+    frameFailureRetryable = true
+    host.Wake()
+    return true
+  }
+
   internal prop ReadbackState VulkanReadbackState{
     get {
       if let request = readbackRequest {

--- a/tests/Goo.AsyncReadbackSmoke/ClipCaptureSmoke.gs
+++ b/tests/Goo.AsyncReadbackSmoke/ClipCaptureSmoke.gs
@@ -1,0 +1,124 @@
+package GooAsyncReadbackSmoke
+
+import System
+import System.Diagnostics
+import System.IO
+import System.Threading
+import Goo
+import GooReadbackFixture
+
+func ClipCaptureReadback(window Window, metrics WindowMetrics)
+VulkanReadbackResult{
+  let deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 10L
+  var status = WindowReadbackTestFixture.Request(window,
+    uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+  while status == VulkanReadbackRequestStatus.Busy
+    || status == VulkanReadbackRequestStatus.NotReady{
+      if Stopwatch.GetTimestamp() >= deadline {
+        throw InvalidOperationException(
+          "Clip capture readback request did not become accepted")
+      }
+      WindowReadbackTestFixture.Pump(window, 0.0)
+      Thread.Yield()
+      status = WindowReadbackTestFixture.Request(window,
+        uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+    }
+  Require(status == VulkanReadbackRequestStatus.Accepted,
+    "Clip capture readback was not accepted: " + status.ToString())
+  ReadbackAwaitReadbackReady(window, 10000)
+  let result = ReadbackTakeReadback(window)
+  PrimitiveValidateResult(result, metrics)
+  return result
+}
+
+func RunClipCaptureSmoke() {
+  Require(Environment.GetEnvironmentVariable("GOO_VK_DIAGNOSTICS") == "1",
+    "GOO_VK_DIAGNOSTICS=1 is required")
+  let fontPath = Path.Combine(AppContext.BaseDirectory, "VendSans-VariableFont_wght.ttf")
+  Require(File.Exists(fontPath), "Clip capture text font asset is missing")
+  let font = FontSource("ReadbackGateFont", 400, false, File.ReadAllBytes(fontPath))
+  font.Register()
+  let root = RoundedOverflowCell{}
+  let capturedError = StringWriter()
+  let originalError = Console.Error
+  var window Window? = nil
+  try {
+    let opened = Window{
+      Title: "Goo clip capture submission gate",
+      Width: 400,
+      Height: 190,
+      VSync: false,
+      Root: root,
+    }
+    window = opened
+    Console.SetError(capturedError)
+    opened.Open()
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    let metrics = WindowReadbackTestFixture.Metrics(opened)
+    Require(RoundedOverflowCell.ClipOuter.IsMounted
+        && RoundedOverflowCell.ClipInner.IsMounted,
+      "Clip capture scene did not mount nested clip paths")
+
+    let first = ClipCaptureReadback(opened, metrics)
+    let staged = WindowReadbackTestFixture.Request(opened,
+      uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+    Require(staged == VulkanReadbackRequestStatus.NotReady,
+      "Clip capture second prerequisite frame was not staged: " + staged.ToString())
+    WindowReadbackTestFixture.DrainWindowQueue(opened, 2000)
+
+    let accepted = WindowReadbackTestFixture.Request(opened,
+      uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+    Require(accepted == VulkanReadbackRequestStatus.Accepted,
+      "Clip capture second readback was not accepted: " + accepted.ToString())
+    let submissionDeadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 2L
+    while !WindowReadbackTestFixture.SubmissionReadyForReconcile(opened)
+      && Stopwatch.GetTimestamp() < submissionDeadline{
+        Thread.Yield()
+      }
+    Require(WindowReadbackTestFixture.SubmissionReadyForReconcile(opened),
+      "Clip capture offscreen submit did not complete before reconciliation")
+
+    WindowReadbackTestFixture.SetForceFullRedraw(opened, true)
+    var frame int32 = 0
+    while frame < 4 {
+      WindowReadbackTestFixture.ForceRenderNonblocking(opened, 0.0)
+      frame = frame + 1
+    }
+
+    ReadbackAwaitReadbackReady(opened, 10000)
+    let second = ReadbackTakeReadback(opened)
+    PrimitiveValidateResult(second, metrics)
+    Require(first.Pixels.Length == second.Pixels.Length,
+      "Clip capture repeated readback byte count changed")
+    PrimitiveRequirePixelNear(second.Pixels, second.Width, metrics,
+      290.0, 86.0, uint8(12), uint8(20), uint8(32), 8, "outer_clip_corner")
+    PrimitiveRequirePixelNear(second.Pixels, second.Width, metrics,
+      340.0, 130.0, uint8(236), uint8(196), uint8(72), 24,
+      "transformed_leaf")
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    Require(WindowReadbackTestFixture.RequestCount(opened) == 2uL
+        && WindowReadbackTestFixture.CompletionCount(opened) == 2uL,
+      "Clip capture readback lifecycle counts are incorrect")
+
+    opened.RequestClose()
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    Require(!opened.IsOpen, "Clip capture window did not close")
+  } finally {
+    Console.SetError(originalError)
+    if let active = window {
+      if active.IsOpen {
+        active.RequestClose()
+        WindowReadbackTestFixture.ForceRender(active, 0.0)
+      }
+    }
+    font.Dispose()
+  }
+  let diagnostics = capturedError.ToString()
+  ReadbackValidateCommonDiagnostics(diagnostics)
+  Require(!diagnostics.Contains("\"event\":325")
+      && !diagnostics.Contains("\"event\":326"),
+    "Clip capture emitted unsupported-scene diagnostics")
+  Require(DiagnosticCounter(diagnostics, "readbackCount") == 2uL,
+    "Clip capture diagnostics did not record two readbacks")
+  Console.WriteLine("clip-capture-submission-gate: captures=2 submission_ready=1 live_frames=4 pixels=validated close=1")
+}

--- a/tests/Goo.AsyncReadbackSmoke/Program.gs
+++ b/tests/Goo.AsyncReadbackSmoke/Program.gs
@@ -3295,6 +3295,10 @@ if Environment.GetEnvironmentVariable("GOO_ROUNDED_OVERFLOW_SMOKE") == "1" {
   RunRoundedOverflowSmoke()
   return
 }
+if Environment.GetEnvironmentVariable("GOO_CLIP_CAPTURE_SMOKE") == "1" {
+  RunClipCaptureSmoke()
+  return
+}
 if Environment.GetEnvironmentVariable("GOO_PRIMITIVE_PIXEL_SMOKE") == "1" {
   RunPrimitivePixelSmoke()
   return

--- a/tests/Goo.AsyncReadbackSmoke/WindowReadbackFixture.gs
+++ b/tests/Goo.AsyncReadbackSmoke/WindowReadbackFixture.gs
@@ -706,6 +706,8 @@ public partial class Window {
     return target.ReadbackCompletionCount
   }
 
+  internal func ReadbackSubmissionReadyForReconcileForTest() bool -> windowTarget?.ReadbackSubmissionReadyForReconcile == true
+
   internal func ReadbackResidentResourceBytesForTest() uint64 {
     guard let target = windowTarget else {
       return 0uL
@@ -1096,6 +1098,8 @@ internal class WindowReadbackTestFixture {
     internal func RequestCount(window Window) uint64 -> window.ReadbackRequestCountForTest()
 
     internal func CompletionCount(window Window) uint64 -> window.ReadbackCompletionCountForTest()
+
+    internal func SubmissionReadyForReconcile(window Window) bool -> window.ReadbackSubmissionReadyForReconcileForTest()
 
     internal func ResidentResourceBytes(window Window) uint64 -> window.ReadbackResidentResourceBytesForTest()
     internal func TargetResidentResourceBytes(target VulkanWindowTarget?) uint64 {


### PR DESCRIPTION
Fixes #24

Reconcile an offscreen readback queue submission before a live window frame records against the shared clip-mask atlas. If the queue result is not available yet, defer the live frame and wake it for retry. GPU completion remains asynchronous.

Adds a deterministic regression that completes the second offscreen submit without polling it, then demands four live frames. The upstream implementation throws the reported active usage-batch exception at that point. The fixed implementation completes both captures, validates clipped pixels, reports clean Vulkan diagnostics, and closes without retained objects.

Verification:
- strict Goo Release build
- strict AsyncReadbackSmoke build
- issue gate passed three consecutive validation-enabled runs
- default async readback gate
- mixed-axis and nested clip readback gate
- effects readback gate
- API contract tests: 10 passed
- core behavior tests: 273 passed