### PR TITLE
Fix Vulkan overflow padding-edge clipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,11 @@ jobs:
             GOO_CLIP_CAPTURE_SMOKE=1 \
             dotnet tests/Goo.AsyncReadbackSmoke/bin/Release/net10.0/Goo.AsyncReadbackSmoke.dll
 
+          .github/scripts/with-headless-wayland.sh env \
+            GOO_VK_DIAGNOSTICS=1 \
+            GOO_PADDING_EDGE_OVERFLOW_SMOKE=1 \
+            dotnet tests/Goo.AsyncReadbackSmoke/bin/Release/net10.0/Goo.AsyncReadbackSmoke.dll
+
       - name: Record dependencies and reject known vulnerabilities
         run: |
           mkdir -p artifacts/reports

--- a/Goo/Rendering/Vulkan/VulkanSceneCompiler.Core.gs
+++ b/Goo/Rendering/Vulkan/VulkanSceneCompiler.Core.gs
@@ -982,18 +982,19 @@ internal partial class VulkanSceneCompiler {
       let clipsY = overflowPreflight.ClipsY
       let bothAxes = overflowPreflight.BothAxes
       let hasRadius = overflowPreflight.HasRadius
+      let paddingEdgeBounds = PaddingEdgeBounds(node, bounds)
       var overflowPathClipChainId = activePathClipChainId
       var roundedOverflowClip = false
       var mixedOverflowClip = false
       if hasRadius {
-        let roundedClip = ResolveRoundedOverflowClip(node, bounds, transform.Index,
-          activePathClipChainId)
+        let roundedClip = ResolveRoundedOverflowClip(node, bounds, paddingEdgeBounds,
+          transform.Index, activePathClipChainId)
         if roundedClip.Emitted {
           overflowPathClipChainId = roundedClip.ChainIndex
           roundedOverflowClip = true
         }
       } else if clipsX != clipsY {
-        let mixedClip = ResolveMixedOverflowClip(node, bounds, transform.Index,
+        let mixedClip = ResolveMixedOverflowClip(node, paddingEdgeBounds, transform.Index,
           activePathClipChainId, clipsX)
         if mixedClip.Emitted {
           overflowPathClipChainId = mixedClip.ChainIndex
@@ -1026,7 +1027,7 @@ internal partial class VulkanSceneCompiler {
               ? 0 : frame.ClipChains[activePathClipChainId].Depth) >= MaxPathClipDepth
           if overflowPreflight.RectangularEmittable {
             let clip = RectClipRecord{
-              Bounds: bounds,
+              Bounds: paddingEdgeBounds,
               TransformIndex: transform.Index,
               ParentIndex: parentClipIndex,
             }
@@ -1120,7 +1121,7 @@ internal partial class VulkanSceneCompiler {
       let resolvedTransform = ResolveCompilerFrameTransform(transform.Index)
       if clipIndex >= 0 {
         childClipBounds = IntersectBounds(childClipBounds,
-          TransformCompilerBounds(bounds, resolvedTransform))
+          TransformCompilerBounds(paddingEdgeBounds, resolvedTransform))
       }
       if pathClip.Emitted {
         childClipBounds = IntersectBounds(childClipBounds,
@@ -1172,7 +1173,7 @@ internal partial class VulkanSceneCompiler {
         }
         if clipIndex >= 0 {
           frame.AddRectClipEnd(RectClipRecord{
-            Bounds: bounds,
+            Bounds: paddingEdgeBounds,
             TransformIndex: transform.Index,
             ParentIndex: parentClipIndex,
           })
@@ -1307,6 +1308,7 @@ internal partial class VulkanSceneCompiler {
   private func ResolveRoundedOverflowClip(
     node Node,
     bounds ConservativeBounds,
+    clipBounds ConservativeBounds,
     transformIndex int32,
     parentChainId int32) VulkanScenePathClipResult{
       if bounds.IsEmpty || parentChainId < 0 || parentChainId >= frame.ClipChainCount {
@@ -1316,6 +1318,14 @@ internal partial class VulkanSceneCompiler {
       if parentDepth >= MaxPathClipDepth {
         return VulkanScenePathClipResult{}
       }
+      if clipBounds.IsEmpty {
+        let stableId = OwnerId(node) | OverflowClipMaskBit
+        var contentKey = HashPathBounds(stableId, clipBounds)
+        contentKey = MixPathHash(contentKey, OverflowClipMaskBit)
+        let chain = frame.AddZeroClipChain(parentChainId, stableId, contentKey)
+        clipChainCount = frame.ClipChainCount - 1
+        return VulkanScenePathClipResult{ Emitted: true, ChainIndex: chain }
+      }
       let entry = if roundedOverflowPaths.TryGetValue(node, out var existing) {
         existing
       } else {
@@ -1323,20 +1333,24 @@ internal partial class VulkanSceneCompiler {
         roundedOverflowPaths.Add(node, created)
         created
       }
-      let topLeft = Radius(node.BorderTopLeftRadius, node.BorderRadius, bounds)
-      let topRight = Radius(node.BorderTopRightRadius, node.BorderRadius, bounds)
-      let bottomRight = Radius(node.BorderBottomRightRadius, node.BorderRadius, bounds)
-      let bottomLeft = Radius(node.BorderBottomLeftRadius, node.BorderRadius, bounds)
+      let topLeft = PaddingEdgeRadius(node, node.BorderTopLeftRadius,
+        node.BorderRadius, bounds, clipBounds, true, true)
+      let topRight = PaddingEdgeRadius(node, node.BorderTopRightRadius,
+        node.BorderRadius, bounds, clipBounds, false, true)
+      let bottomRight = PaddingEdgeRadius(node, node.BorderBottomRightRadius,
+        node.BorderRadius, bounds, clipBounds, false, false)
+      let bottomLeft = PaddingEdgeRadius(node, node.BorderBottomLeftRadius,
+        node.BorderRadius, bounds, clipBounds, true, false)
       let clipPath = entry.Resolve(
-        topLeft / bounds.Width, topLeft / bounds.Height,
-        topRight / bounds.Width, topRight / bounds.Height,
-        bottomRight / bounds.Width, bottomRight / bounds.Height,
-        bottomLeft / bounds.Width, bottomLeft / bounds.Height)
+        topLeft / clipBounds.Width, topLeft / clipBounds.Height,
+        topRight / clipBounds.Width, topRight / clipBounds.Height,
+        bottomRight / clipBounds.Width, bottomRight / clipBounds.Height,
+        bottomLeft / clipBounds.Width, bottomLeft / clipBounds.Height)
       let stableId = OwnerId(node) | OverflowClipMaskBit
       let mapping = PathGeometry.Map(clipPath, ShapeFit.Fill,
-        bounds.X, bounds.Y, bounds.Width, bounds.Height)
+        clipBounds.X, clipBounds.Y, clipBounds.Width, clipBounds.Height)
       var contentKey = ClipContentKey(node, clipPath, ShapeFit.Fill,
-        uint32(FillRule.NonZero), bounds, transformIndex)
+        uint32(FillRule.NonZero), clipBounds, transformIndex)
       contentKey = MixPathHash(contentKey, OverflowClipMaskBit)
       if !mapping.Valid || mapping.ScaleX == 0.0F || mapping.ScaleY == 0.0F {
         let chain = frame.AddZeroClipChain(parentChainId, stableId, contentKey)
@@ -1362,7 +1376,7 @@ internal partial class VulkanSceneCompiler {
         AtlasId: path.AtlasId,
         AtlasWordOffset: path.BaseWord,
         AtlasWordCount: path.WordCount,
-        Bounds: bounds,
+        Bounds: clipBounds,
         PathBounds: MappedPathBounds(path.Bounds, mapping),
         Fit: ShapeFit.Fill,
         FillRule: path.FillRule,
@@ -1392,12 +1406,21 @@ internal partial class VulkanSceneCompiler {
     transformIndex int32,
     parentChainId int32,
     clipsX bool) VulkanScenePathClipResult{
-      if bounds.IsEmpty || parentChainId < 0 || parentChainId >= frame.ClipChainCount {
+      if parentChainId < 0 || parentChainId >= frame.ClipChainCount {
         return VulkanScenePathClipResult{}
       }
       let parentDepth = parentChainId == 0 ? 0 : frame.ClipChains[parentChainId].Depth
       if parentDepth >= MaxPathClipDepth {
         return VulkanScenePathClipResult{}
+      }
+      if clipsX ? bounds.Width <= 0.0F : bounds.Height <= 0.0F {
+        let stableId = OwnerId(node) | OverflowClipMaskBit
+        var contentKey = HashPathBounds(stableId, bounds)
+        contentKey = MixPathHash(contentKey, OverflowClipMaskBit)
+        contentKey = MixPathHash(contentKey, clipsX ? 1uL : 2uL)
+        let chain = frame.AddZeroClipChain(parentChainId, stableId, contentKey)
+        clipChainCount = frame.ClipChainCount - 1
+        return VulkanScenePathClipResult{ Emitted: true, ChainIndex: chain }
       }
       let clipBounds = MixedOverflowBounds(node, bounds, clipsX)
       if clipBounds.IsEmpty {
@@ -1478,9 +1501,11 @@ internal partial class VulkanSceneCompiler {
     node Node,
     bounds ConservativeBounds,
     clipsX bool) ConservativeBounds{
-      if bounds.IsEmpty || clipViewportWidth <= 0.0F || clipViewportHeight <= 0.0F {
-        return ConservativeBounds{}
-      }
+      let clippedExtent = clipsX ? bounds.Width : bounds.Height
+      if clippedExtent <= 0.0F || clipViewportWidth <= 0.0F
+        || clipViewportHeight <= 0.0F {
+          return ConservativeBounds{}
+        }
       let topLeft = TransformGeometry.WindowToNode(node, 0.0F, 0.0F)
       let topRight = TransformGeometry.WindowToNode(node, clipViewportWidth, 0.0F)
       let bottomLeft = TransformGeometry.WindowToNode(node, 0.0F, clipViewportHeight)

--- a/Goo/Rendering/Vulkan/VulkanSceneCompiler.Paint.gs
+++ b/Goo/Rendering/Vulkan/VulkanSceneCompiler.Paint.gs
@@ -537,7 +537,7 @@ internal partial class VulkanSceneCompiler {
           && Finite(shadow.Blur.Value)
           && Finite(shadow.Spread.Value)
           && shadow.Blur.Value >= 0.0F
-        let shadowBounds = insetOnly ? InsetShadowBounds(node, bounds) : bounds
+        let shadowBounds = insetOnly ? PaddingEdgeBounds(node, bounds) : bounds
         if !supportedOwner || !validGeometry {
           RecordUnsupportedDetail(node, VulkanSceneUnsupportedField.BoxShadows,
             VulkanSceneUnsupportedPrimitive.BoxShadow)
@@ -545,16 +545,16 @@ internal partial class VulkanSceneCompiler {
           frame.AddShadow(ShadowRecord{
             Bounds: shadowBounds,
             RadiusTopLeft: insetOnly
-            ? InsetShadowRadius(node, node.BorderTopLeftRadius, node.BorderRadius,
+            ? PaddingEdgeRadius(node, node.BorderTopLeftRadius, node.BorderRadius,
               bounds, shadowBounds, true, true) : Radius(node.BorderTopLeftRadius, node.BorderRadius, bounds),
             RadiusTopRight: insetOnly
-            ? InsetShadowRadius(node, node.BorderTopRightRadius, node.BorderRadius,
+            ? PaddingEdgeRadius(node, node.BorderTopRightRadius, node.BorderRadius,
               bounds, shadowBounds, false, true) : Radius(node.BorderTopRightRadius, node.BorderRadius, bounds),
             RadiusBottomRight: insetOnly
-            ? InsetShadowRadius(node, node.BorderBottomRightRadius, node.BorderRadius,
+            ? PaddingEdgeRadius(node, node.BorderBottomRightRadius, node.BorderRadius,
               bounds, shadowBounds, false, false) : Radius(node.BorderBottomRightRadius, node.BorderRadius, bounds),
             RadiusBottomLeft: insetOnly
-            ? InsetShadowRadius(node, node.BorderBottomLeftRadius, node.BorderRadius,
+            ? PaddingEdgeRadius(node, node.BorderBottomLeftRadius, node.BorderRadius,
               bounds, shadowBounds, true, false) : Radius(node.BorderBottomLeftRadius, node.BorderRadius, bounds),
             OffsetX: shadow.OffsetX.Px,
             OffsetY: shadow.OffsetY.Px,
@@ -758,7 +758,7 @@ internal partial class VulkanSceneCompiler {
       return result == 0uL ? 1uL : result
     }
 
-  private func InsetShadowBounds(node Node, bounds ConservativeBounds) ConservativeBounds {
+  private func PaddingEdgeBounds(node Node, bounds ConservativeBounds) ConservativeBounds {
     let basis = MinDimension(bounds)
     let left = ResolveLength(node.BorderLeftWidth, basis)
     let top = ResolveLength(node.BorderTopWidth, basis)
@@ -777,7 +777,7 @@ internal partial class VulkanSceneCompiler {
     }
   }
 
-  private func InsetShadowRadius(
+  private func PaddingEdgeRadius(
     node Node,
     value Length,
     fallback Length,

--- a/tests/Goo.AsyncReadbackSmoke/PaddingEdgeOverflowSmoke.gs
+++ b/tests/Goo.AsyncReadbackSmoke/PaddingEdgeOverflowSmoke.gs
@@ -1,0 +1,316 @@
+package GooAsyncReadbackSmoke
+
+import System
+import System.Diagnostics
+import System.IO
+import System.Threading
+import Goo
+import GooReadbackFixture
+
+class PaddingEdgeOverflowCell : Cell {
+  shared {
+    let Root ElementHandle = ElementHandle{}
+    let ReferenceBox ElementHandle = ElementHandle{}
+    let OverflowBox ElementHandle = ElementHandle{}
+    let RectOverflowBox ElementHandle = ElementHandle{}
+    let MixedXOverflowBox ElementHandle = ElementHandle{}
+    let MixedYOverflowBox ElementHandle = ElementHandle{}
+  }
+
+  override func Build() Blob -> Container {
+    Width: Length.Percent(100),
+    Height: Length.Percent(100),
+    Handle: PaddingEdgeOverflowCell.Root,
+    Position: PositionType.Relative,
+    BackgroundColor: Color.Rgb(12, 20, 32),
+    Children: {
+      Container{
+        Position: PositionType.Absolute,
+        Left: 8,
+        Top: 8,
+        Width: 48,
+        Height: 48,
+        Handle: PaddingEdgeOverflowCell.ReferenceBox,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        BorderRadius: 12,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 72,
+        Top: 8,
+        Width: 48,
+        Height: 48,
+        Handle: PaddingEdgeOverflowCell.OverflowBox,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        BorderRadius: 12,
+        Overflow: Overflow.Hidden,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+        Children: {
+          Container{
+            Position: PositionType.Absolute,
+            Left: 0,
+            Top: 0,
+            Width: Length.Percent(100),
+            Height: Length.Percent(100),
+            BackgroundColor: Color.Rgb(220, 40, 48),
+          },
+        },
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 136,
+        Top: 8,
+        Width: 48,
+        Height: 48,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 200,
+        Top: 8,
+        Width: 48,
+        Height: 48,
+        Handle: PaddingEdgeOverflowCell.RectOverflowBox,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        Overflow: Overflow.Hidden,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+        Children: {
+          Container{
+            Position: PositionType.Absolute,
+            Left: -1,
+            Top: -1,
+            Width: 48,
+            Height: 48,
+            BackgroundColor: Color.Rgb(220, 40, 48),
+          },
+        },
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 8,
+        Top: 72,
+        Width: 48,
+        Height: 48,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 72,
+        Top: 72,
+        Width: 48,
+        Height: 48,
+        Handle: PaddingEdgeOverflowCell.MixedXOverflowBox,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        OverflowX: Overflow.Hidden,
+        OverflowY: Overflow.Visible,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+        Children: {
+          Container{
+            Position: PositionType.Absolute,
+            Left: -1,
+            Top: -1,
+            Width: 48,
+            Height: 48,
+            BackgroundColor: Color.Rgb(220, 40, 48),
+          },
+        },
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 136,
+        Top: 72,
+        Width: 48,
+        Height: 48,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+      },
+      Container{
+        Position: PositionType.Absolute,
+        Left: 200,
+        Top: 72,
+        Width: 48,
+        Height: 48,
+        Handle: PaddingEdgeOverflowCell.MixedYOverflowBox,
+        BorderWidth: 1,
+        BorderColor: Color.White,
+        OverflowX: Overflow.Visible,
+        OverflowY: Overflow.Hidden,
+        BackgroundColor: Color.Rgb(220, 40, 48),
+        Children: {
+          Container{
+            Position: PositionType.Absolute,
+            Left: -1,
+            Top: -1,
+            Width: 48,
+            Height: 48,
+            BackgroundColor: Color.Rgb(220, 40, 48),
+          },
+        },
+      },
+    },
+  }
+}
+
+func PaddingEdgeRequirePair(pixels []uint8, width uint32, metrics WindowMetrics,
+  referenceX float64, referenceY float64, overflowX float64, overflowY float64,
+  x float64, y float64, name string) {
+    let reference = PrimitiveLogicalPixel(pixels, width, metrics,
+      referenceX + x, referenceY + y)
+    let overflow = PrimitiveLogicalPixel(pixels, width, metrics,
+      overflowX + x, overflowY + y)
+    let difference = Math.Abs(int32(reference[0]) - int32(overflow[0]))
+    +Math.Abs(int32(reference[1]) - int32(overflow[1]))
+    +Math.Abs(int32(reference[2]) - int32(overflow[2]))
+    if difference > 36 || reference[3] < uint8(240) || overflow[3] < uint8(240) {
+      throw InvalidOperationException("Padding-edge border sample " + name
+        +" differs: reference=" + PrimitivePixelText(reference)
+        +" overflow=" + PrimitivePixelText(overflow))
+    }
+  }
+
+func PaddingEdgeValidateScale(result VulkanReadbackResult, metrics WindowMetrics,
+  name string) {
+    let pixels = result.Pixels
+    let width = result.Width
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      3.5, 3.5, name + "_rounded_top_left")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      44.5, 3.5, name + "_rounded_top_right")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      44.5, 44.5, name + "_rounded_bottom_right")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      3.5, 44.5, name + "_rounded_bottom_left")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      24.0, 1.0, name + "_rounded_top")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      46.5, 24.0, name + "_rounded_right")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      24.0, 46.5, name + "_rounded_bottom")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 8.0, 72.0, 8.0,
+      1.0, 24.0, name + "_rounded_left")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 8.0, 200.0, 8.0,
+      24.0, 1.0, name + "_rect_top")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 8.0, 200.0, 8.0,
+      46.5, 24.0, name + "_rect_right")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 8.0, 200.0, 8.0,
+      24.0, 46.5, name + "_rect_bottom")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 8.0, 200.0, 8.0,
+      1.0, 24.0, name + "_rect_left")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 72.0, 72.0, 72.0,
+      46.5, 24.0, name + "_mixed_x_right")
+    PaddingEdgeRequirePair(pixels, width, metrics, 8.0, 72.0, 72.0, 72.0,
+      1.0, 24.0, name + "_mixed_x_left")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 72.0, 200.0, 72.0,
+      24.0, 1.0, name + "_mixed_y_top")
+    PaddingEdgeRequirePair(pixels, width, metrics, 136.0, 72.0, 200.0, 72.0,
+      24.0, 46.5, name + "_mixed_y_bottom")
+  }
+
+func PaddingEdgeReadback(window Window, metrics WindowMetrics) VulkanReadbackResult {
+  let deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 10L
+  var status = WindowReadbackTestFixture.Request(window,
+    uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+  while status == VulkanReadbackRequestStatus.Busy
+    || status == VulkanReadbackRequestStatus.NotReady{
+      if Stopwatch.GetTimestamp() >= deadline {
+        throw InvalidOperationException(
+          "Padding-edge readback request did not become accepted")
+      }
+      WindowReadbackTestFixture.Pump(window, 0.0)
+      Thread.Yield()
+      status = WindowReadbackTestFixture.Request(window,
+        uint32(metrics.FramebufferWidth), uint32(metrics.FramebufferHeight))
+    }
+  Require(status == VulkanReadbackRequestStatus.Accepted,
+    "Padding-edge readback was not accepted: " + status.ToString())
+  ReadbackAwaitReadbackReady(window, 10000)
+  let result = ReadbackTakeReadback(window)
+  PrimitiveValidateResult(result, metrics)
+  return result
+}
+
+func RunPaddingEdgeOverflowSmoke() {
+  Require(Environment.GetEnvironmentVariable("GOO_VK_DIAGNOSTICS") == "1",
+    "GOO_VK_DIAGNOSTICS=1 is required")
+  let capturedError = StringWriter()
+  let originalError = Console.Error
+  var window Window? = nil
+  try {
+    let opened = Window{
+      Title: "Goo padding-edge overflow gate",
+      Width: 256,
+      Height: 128,
+      VSync: false,
+      Root: PaddingEdgeOverflowCell{},
+    }
+    window = opened
+    Console.SetError(capturedError)
+    opened.Open()
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    var frame int32 = 0
+    while frame < 8 {
+      WindowReadbackTestFixture.ForceRender(opened, 0.0166666666666667)
+      frame = frame + 1
+    }
+    let integerMetrics = WindowReadbackTestFixture.Metrics(opened)
+    Require(integerMetrics.LogicalWidth == 256 && integerMetrics.LogicalHeight == 128,
+      "Padding-edge integer metrics are incorrect")
+    Require(PaddingEdgeOverflowCell.Root.IsMounted
+        && PaddingEdgeOverflowCell.ReferenceBox.IsMounted
+        && PaddingEdgeOverflowCell.OverflowBox.IsMounted
+        && PaddingEdgeOverflowCell.RectOverflowBox.IsMounted
+        && PaddingEdgeOverflowCell.MixedXOverflowBox.IsMounted
+        && PaddingEdgeOverflowCell.MixedYOverflowBox.IsMounted,
+      "Padding-edge scene did not mount")
+    let integerResult = PaddingEdgeReadback(opened, integerMetrics)
+    PaddingEdgeValidateScale(integerResult, integerMetrics, "integer")
+
+    Require(WindowReadbackTestFixture.Resize(opened, 256, 128, 320, 160),
+      "Padding-edge fractional resize was rejected")
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    frame = 0
+    while frame < 4 {
+      WindowReadbackTestFixture.ForceRender(opened, 0.0166666666666667)
+      frame = frame + 1
+    }
+    let fractionalMetrics = WindowReadbackTestFixture.Metrics(opened)
+    Require(Math.Abs(fractionalMetrics.DisplayScaleX - 1.25) < 0.001
+        && Math.Abs(fractionalMetrics.DisplayScaleY - 1.25) < 0.001,
+      "Padding-edge fractional metrics are incorrect")
+    let fractionalResult = PaddingEdgeReadback(opened, fractionalMetrics)
+    PaddingEdgeValidateScale(fractionalResult, fractionalMetrics, "fractional")
+    Require(WindowReadbackTestFixture.RequestCount(opened) == 2uL
+        && WindowReadbackTestFixture.CompletionCount(opened) == 2uL,
+      "Padding-edge readback lifecycle counts are incorrect")
+    opened.RequestClose()
+    WindowReadbackTestFixture.ForceRender(opened, 0.0)
+    Require(!opened.IsOpen, "Padding-edge gate window did not close")
+    Require(WindowReadbackTestFixture.ResidentResourceBytes(opened) == 0uL,
+      "Padding-edge readback resources remain resident after close")
+  } finally {
+    Console.SetError(originalError)
+    if let active = window {
+      if active.IsOpen {
+        active.RequestClose()
+        WindowReadbackTestFixture.ForceRender(active, 0.0)
+      }
+    }
+  }
+  let diagnostics = capturedError.ToString()
+  ReadbackValidateCommonDiagnostics(diagnostics)
+  Require(!diagnostics.Contains("\"event\":325")
+      && !diagnostics.Contains("\"event\":326"),
+    "Padding-edge gate emitted unsupported-scene diagnostics")
+  Console.WriteLine("padding-edge-overflow-smoke: paths=rounded,rect,mixed_x,mixed_y"
+    +" scales=1,1.25 samples=32 readbacks=2 close=1")
+}

--- a/tests/Goo.AsyncReadbackSmoke/Program.gs
+++ b/tests/Goo.AsyncReadbackSmoke/Program.gs
@@ -3295,6 +3295,10 @@ if Environment.GetEnvironmentVariable("GOO_ROUNDED_OVERFLOW_SMOKE") == "1" {
   RunRoundedOverflowSmoke()
   return
 }
+if Environment.GetEnvironmentVariable("GOO_PADDING_EDGE_OVERFLOW_SMOKE") == "1" {
+  RunPaddingEdgeOverflowSmoke()
+  return
+}
 if Environment.GetEnvironmentVariable("GOO_CLIP_CAPTURE_SMOKE") == "1" {
   RunClipCaptureSmoke()
   return


### PR DESCRIPTION
Fixes #25

## Change

- resolve descendant overflow clips from padding-edge bounds
- reduce rounded clip radii by the maximum adjacent border width
- apply padding-edge geometry to rectangular, rounded, and mixed-axis overflow
- reuse the same geometry resolver for inset shadows
- add a validation-enabled readback lane for all four overflow paths at 1.0x and 1.25x display scales

## Verification

- strict Goo Release build, 0 warnings and 0 errors
- strict AsyncReadbackSmoke Release build, 0 warnings and 0 errors
- API contract tests: 10 passed
- core behavior tests: 273 passed
- padding-edge overflow E2E: 32 samples across rounded, rectangular, mixed-X, and mixed-Y clips at 1.0x and 1.25x
- rounded-overflow E2E passed
- clip-capture E2E passed
- effects E2E passed
- default readback E2E passed
- Vulkan validation diagnostics reported no errors
