### PR TITLE
Drop invalid render: gsharp from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,7 +45,6 @@ body:
     attributes:
       label: Minimal reproduction
       description: Provide the smallest code sample and exact steps that reproduce the defect.
-      render: gsharp
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/core-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/core-proposal.yml
@@ -45,7 +45,6 @@ body:
     attributes:
       label: Current public surface
       description: List the Goo APIs you tried and show the smallest composition attempt.
-      render: gsharp
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -45,7 +45,6 @@ body:
     attributes:
       label: Current code
       description: Show the smallest relevant composition.
-      render: gsharp
     validations:
       required: true
 


### PR DESCRIPTION
Clicking New issue only offered the API reference contact link. The real forms never showed up.

config.yml is fine. Three forms set `render: gsharp`, and gsharp is not a Linguist language, so GitHub rejected those templates and left only contact_links. This removes the invalid render keys.

Fixes #31