### PR TITLE
Fix issue form titles and NuGet README validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a reproducible defect in Goo
-title: ""
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/core-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/core-proposal.yml
@@ -1,6 +1,5 @@
 name: Core proposal
 description: Propose a missing primitive or public API for Goo core
-title: ""
 labels:
   - proposal
 body:

--- a/.github/ISSUE_TEMPLATE/dogfood-gap.yml
+++ b/.github/ISSUE_TEMPLATE/dogfood-gap.yml
@@ -1,6 +1,5 @@
 name: Owner dogfood gap
 description: Repository-owner self-report for a capability blocked while building with Goo
-title: ""
 labels:
   - proposal
 body:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,5 @@
 name: Question
 description: Ask about using or composing Goo primitives
-title: ""
 labels:
   - question
 body:

--- a/.github/scripts/validate-release.py
+++ b/.github/scripts/validate-release.py
@@ -157,8 +157,14 @@ def validate_package(path: Path) -> str:
             raise SystemExit(
                 f"package allowlist mismatch; missing={sorted(missing)}, "
                 f"unexpected={sorted(unexpected)}, metadata={sorted(variable)}")
-        for name in ("README.md", "CHANGELOG.md", "LICENSE", "THIRD-PARTY-NOTICES.md"):
-            if archive.read(name) != (ROOT / name).read_bytes():
+        package_sources = {
+            "README.md": ROOT / "docs/nuget-readme.md",
+            "CHANGELOG.md": ROOT / "CHANGELOG.md",
+            "LICENSE": ROOT / "LICENSE",
+            "THIRD-PARTY-NOTICES.md": ROOT / "THIRD-PARTY-NOTICES.md",
+        }
+        for name, source in package_sources.items():
+            if archive.read(name) != source.read_bytes():
                 raise SystemExit(f"package {name} differs from the release tree")
         if archive.read("buildTransitive/Goo.targets") != (ROOT / "Goo/Goo.targets").read_bytes():
             raise SystemExit("packaged Goo.targets differs from the release tree")


### PR DESCRIPTION
Follow-up to #32.

GitHub rejects empty strings for string-valued issue-form fields. Every form still sets the optional top-level `title` field to an empty string, so the chooser suppresses all four forms.

This removes the empty `title` key from the bug, core proposal, owner dogfood, and question forms.

The initial CI runs exposed an existing `main` regression from #30: the release validator compared the package README against the repository root even though packaging now intentionally sources `docs/nuget-readme.md`. The second commit aligns that validation with the packed source while leaving bundle validation against the root README unchanged.

Verification:
- Parsed every issue-form YAML file successfully.
- Confirmed no empty `title` fields remain.
- Confirmed the packed README matches `docs/nuget-readme.md`.
- Compiled `validate-release.py` successfully.
- `git diff --check` passes.

Fixes #31