### PR TITLE
Expose native window activation requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,11 @@ jobs:
 
           .github/scripts/with-headless-wayland.sh env \
             GOO_VK_DIAGNOSTICS=1 \
+            GOO_WINDOW_ACTIVATION_SMOKE=1 \
+            dotnet tests/Goo.AsyncReadbackSmoke/bin/Release/net10.0/Goo.AsyncReadbackSmoke.dll
+
+          .github/scripts/with-headless-wayland.sh env \
+            GOO_VK_DIAGNOSTICS=1 \
             GOO_TIMELINE_COMPLETION_SMOKE=1 \
             dotnet tests/Goo.AsyncReadbackSmoke/bin/Release/net10.0/Goo.AsyncReadbackSmoke.dll
 

--- a/Goo/Platform/EmbeddedWindowBridge.gs
+++ b/Goo/Platform/EmbeddedWindowBridge.gs
@@ -66,6 +66,7 @@ internal class EmbeddedWindowBridge : WindowHost, VulkanSurfaceHost {
   public func SetSize(width int32, height int32) { }
   public func SetPosition(x int32, y int32) { }
   public func SetState(value WindowState) { }
+  public func RequestActivation() WindowActivationResult -> WindowActivationResult.Unsupported
   public func SetBorder(decorated bool, resizable bool) { }
   public func SetVSync(value bool) { }
   public func SetCursor(value Cursor) { host.ChangeCursor(value) }

--- a/Goo/Platform/Sdl/SdlHost.gs
+++ b/Goo/Platform/Sdl/SdlHost.gs
@@ -266,6 +266,18 @@ internal unsafe partial class SdlHost : IDisposable, WindowHost, VulkanSurfaceHo
     }
   }
 
+  public func RequestActivation() WindowActivationResult {
+    if disposed || IsClosing { return WindowActivationResult.Closed }
+    let flags = SDL.GetWindowFlags(window)
+    if (flags & uint64(SDLWindowFlags.Minimized)) != 0uL && !SDL.RestoreWindow(window) {
+      return WindowActivationResult.Failed
+    }
+    if (flags & uint64(SDLWindowFlags.Hidden)) != 0uL && !SDL.ShowWindow(window) {
+      return WindowActivationResult.Failed
+    }
+    return SDL.RaiseWindow(window) ? WindowActivationResult.Accepted : WindowActivationResult.Failed
+  }
+
   public func SetBorder(decorated bool, resizable bool) {
     ThrowIfDisposed()
     if !decorated {

--- a/Goo/Platform/WindowHost.gs
+++ b/Goo/Platform/WindowHost.gs
@@ -65,6 +65,7 @@ internal interface WindowHost {
   func SetSize(width int32, height int32);
   func SetPosition(x int32, y int32);
   func SetState(value WindowState);
+  func RequestActivation() WindowActivationResult;
   func SetBorder(decorated bool, resizable bool);
   func SetVSync(value bool);
   func SetCursor(value Cursor);

--- a/Goo/Window/WindowParts/Window.Activation.gs
+++ b/Goo/Window/WindowParts/Window.Activation.gs
@@ -1,0 +1,24 @@
+package Goo
+
+/// Reports whether a native window activation request could be submitted.
+/// Accepted does not confirm focus; desktop policy may deny or ignore the request.
+public enum WindowActivationResult { Accepted; Closed; Unsupported; Failed }
+
+/// Hosts a Goo tree in a native window.
+public partial class Window {
+  /// Requests restoration of a minimized window, raising, and keyboard activation.
+  /// Call on the owning UI thread in response to a user action. Desktop policy
+  /// controls the outcome; observe IsFocused and FocusChanged for actual focus.
+  /// Maximized/fullscreen state and the focused Goo element are preserved.
+  /// Returns Closed before Open or after close, Unsupported for embedded hosts,
+  /// or Failed if the native request reports an immediate error. Asynchronous
+  /// policy denials are not reported by the desktop backend.
+  /// Wayland requests use SDL's xdg-activation token and recent input serial.
+  public func RequestActivation() WindowActivationResult {
+    requireUiThread("Window.RequestActivation")
+    if !IsOpen { return WindowActivationResult.Closed }
+    guard let native = host else { return WindowActivationResult.Closed }
+    if native.IsClosing { return WindowActivationResult.Closed }
+    return native.RequestActivation()
+  }
+}

--- a/docs/api/window.md
+++ b/docs/api/window.md
@@ -38,6 +38,7 @@ Sources:
 
 - [`Window.gs`](../../Goo/Window/Window.gs)
 - [`Window.Accessibility.gs`](../../Goo/Window/WindowParts/Window.Accessibility.gs)
+- [`Window.Activation.gs`](../../Goo/Window/WindowParts/Window.Activation.gs)
 - [`Window.Dispatcher.gs`](../../Goo/Window/WindowParts/Window.Dispatcher.gs)
 - [`Window.DragRegion.gs`](../../Goo/Window/WindowParts/Window.DragRegion.gs)
 - [`Window.ElementHandle.gs`](../../Goo/Window/WindowParts/Window.ElementHandle.gs)
@@ -121,6 +122,10 @@ Queues an action for the UI thread.
 Processes one frame with the specified elapsed time.
 
 - `dt`: elapsed seconds since the previous frame
+
+### `RequestActivation`
+
+Requests restoration of a minimized window, raising, and keyboard activation. Call on the owning UI thread in response to a user action. Desktop policy controls the outcome; observe IsFocused and FocusChanged for actual focus. Maximized/fullscreen state and the focused Goo element are preserved. Returns Closed before Open or after close, Unsupported for embedded hosts, or Failed if the native request reports an immediate error. Asynchronous policy denials are not reported by the desktop backend. Wayland requests use SDL's xdg-activation token and recent input serial.
 
 ### `RequestClose`
 
@@ -221,6 +226,21 @@ Gets or sets the requested horizontal position.
 ### `Y`
 
 Gets or sets the requested vertical position.
+
+## `WindowActivationResult`
+
+Source:
+
+- [`Window.Activation.gs`](../../Goo/Window/WindowParts/Window.Activation.gs)
+
+Reports whether a native window activation request could be submitted. Accepted does not confirm focus; desktop policy may deny or ignore the request.
+
+### Values
+
+- `Accepted`
+- `Closed`
+- `Unsupported`
+- `Failed`
 
 ## `WindowMetrics`
 

--- a/tests/Goo.ApiContractTests/PublicApi.approved.txt
+++ b/tests/Goo.ApiContractTests/PublicApi.approved.txt
@@ -110,6 +110,7 @@ enum-underlying|Goo.TextTrimming|System.Int32
 enum-underlying|Goo.TextWrap|System.Int32
 enum-underlying|Goo.TransitionProperty|System.Int32
 enum-underlying|Goo.Visibility|System.Int32
+enum-underlying|Goo.WindowActivationResult|System.Int32
 enum-underlying|Goo.WindowState|System.Int32
 enum|Goo.AccessibilityAction|Activate|1
 enum|Goo.AccessibilityAction|Collapse|9
@@ -525,6 +526,10 @@ enum|Goo.TransitionProperty|Transform|51
 enum|Goo.TransitionProperty|Width|1
 enum|Goo.Visibility|Hidden|1
 enum|Goo.Visibility|Visible|0
+enum|Goo.WindowActivationResult|Accepted|0
+enum|Goo.WindowActivationResult|Closed|1
+enum|Goo.WindowActivationResult|Failed|3
+enum|Goo.WindowActivationResult|Unsupported|2
 enum|Goo.WindowState|Fullscreen|3
 enum|Goo.WindowState|Maximized|2
 enum|Goo.WindowState|Minimized|1
@@ -880,6 +885,7 @@ method|Goo.Window|Open|instance|public|generic:|()->Goo.Window
 method|Goo.Window|PerformAccessibilityAction|instance|public|generic:|(id:Goo.AccessibilityId,request:Goo.AccessibilityActionRequest)->System.Boolean
 method|Goo.Window|Post|instance|public|generic:|(action:System.Action)->System.Void
 method|Goo.Window|Pump|instance|public|generic:|(dt:System.Double)->System.Void
+method|Goo.Window|RequestActivation|instance|public|generic:|()->Goo.WindowActivationResult
 method|Goo.Window|RequestClose|instance|public|generic:|()->System.Void
 method|Goo.Window|Run|instance|public|generic:|()->System.Void
 method|Goo.Window|SetClipboardText|instance|public|generic:|(value:System.String)->System.Void
@@ -1557,6 +1563,7 @@ type|Goo.VectorPath|struct|public|base:System.ValueType|interfaces:|generic:
 type|Goo.VectorStroke|class|public|base:System.Object|interfaces:|generic:
 type|Goo.Visibility|enum|public|base:System.Enum|interfaces:|generic:
 type|Goo.WheelEvent|struct|public|base:System.ValueType|interfaces:|generic:
+type|Goo.WindowActivationResult|enum|public|base:System.Enum|interfaces:|generic:
 type|Goo.WindowMetrics|struct|public|base:System.ValueType|interfaces:|generic:
 type|Goo.WindowState|enum|public|base:System.Enum|interfaces:|generic:
 type|Goo.Window|sealed-class|public|base:System.Object|interfaces:|generic:

--- a/tests/Goo.ApiContractTests/PublicDocumentationTests.cs
+++ b/tests/Goo.ApiContractTests/PublicDocumentationTests.cs
@@ -243,6 +243,7 @@ public sealed class PublicDocumentationTests
         "M:Goo.Window.Post(System.Action)",
         "M:Goo.Window.Open",
         "M:Goo.Window.Pump(System.Double)",
+        "M:Goo.Window.RequestActivation",
         "M:Goo.Window.RequestClose",
         "M:Goo.Window.Run",
         "M:Goo.Window.SetClipboardText(System.String)",

--- a/tests/Goo.AsyncReadbackSmoke/Goo.AsyncReadbackFixtures.props
+++ b/tests/Goo.AsyncReadbackSmoke/Goo.AsyncReadbackFixtures.props
@@ -8,5 +8,7 @@
              Link="DiagnosticCaptureSmoke.gs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedHostSmoke.gs"
              Link="EmbeddedHostSmoke.gs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WindowActivationSmoke.gs"
+             Link="WindowActivationSmoke.gs" />
   </ItemGroup>
 </Project>

--- a/tests/Goo.AsyncReadbackSmoke/Goo.AsyncReadbackSmoke.gsproj
+++ b/tests/Goo.AsyncReadbackSmoke/Goo.AsyncReadbackSmoke.gsproj
@@ -17,6 +17,7 @@
     <Compile Remove="WindowReadbackFixture.gs" />
     <Compile Remove="DiagnosticCaptureSmoke.gs" />
     <Compile Remove="EmbeddedHostSmoke.gs" />
+    <Compile Remove="WindowActivationSmoke.gs" />
     <Compile Include="../Shared/PrimitiveScene.gs" Link="PrimitiveScene.gs" />
     <Compile Include="../Shared/RoundedOverflowScene.gs" Link="RoundedOverflowScene.gs" />
     <Compile Include="../Shared/EffectsScene.gs" Link="EffectsScene.gs" />

--- a/tests/Goo.AsyncReadbackSmoke/Program.gs
+++ b/tests/Goo.AsyncReadbackSmoke/Program.gs
@@ -3253,6 +3253,10 @@ func RunProtectedTextSmoke() {
 
 let managedEntryTimestamp = Stopwatch.GetTimestamp()
 Window.ConfigureApplication("Goo Readback async readback smoke", "0.1.0", "io.github.obselate.goo.readback.readback")
+if Environment.GetEnvironmentVariable("GOO_WINDOW_ACTIVATION_SMOKE") == "1" {
+  WindowActivationSmoke.Run()
+  return
+}
 if Environment.GetEnvironmentVariable("GOO_EMBEDDED_HOST_SMOKE") == "1" {
   EmbeddedHostSmoke.Run()
   return

--- a/tests/Goo.AsyncReadbackSmoke/WindowActivationSmoke.gs
+++ b/tests/Goo.AsyncReadbackSmoke/WindowActivationSmoke.gs
@@ -1,0 +1,79 @@
+package Goo
+
+import System
+import System.Diagnostics
+import System.Threading
+
+internal class WindowActivationCell : Cell {
+  internal let Entry ElementHandle = ElementHandle()
+
+  override func Build() Blob -> TextEntry {
+    Handle: Entry, Value: "Activation preserves this editor",
+    Width: 280, Height: 40,
+  }
+}
+
+internal class WindowActivationSmoke {
+  shared {
+    private func Require(value bool, message string) {
+      if !value { throw InvalidOperationException(message) }
+    }
+
+    internal func Run() {
+      let root = WindowActivationCell{}
+      let window = Window{
+        Title: "Goo activation smoke", Root: root, Width: 320, Height: 100,
+      }.Open()
+      try {
+        WindowReadbackTestFixture.ForceRender(window, 0.0)
+        Require(root.Entry.Focus(), "Activation smoke editor did not focus")
+        guard let editor = window.PlatformInput.Editor else {
+          throw InvalidOperationException("Activation smoke editor state is missing")
+        }
+        var notifications = 0
+        window.FocusChanged += (focused bool) -> { notifications++ }
+        for attempt in 0 ... 3 {
+          let focused = window.IsFocused
+          let events = notifications
+          Require(window.RequestActivation() == WindowActivationResult.Accepted,
+            "Native activation request was not accepted")
+          Require(window.IsFocused == focused && notifications == events,
+            "Activation request synthesized native focus")
+          guard let current = window.PlatformInput.Editor else {
+            throw InvalidOperationException("Activation request lost the focused editor")
+          }
+          Require(current.FocusId == editor.FocusId && current.Text == editor.Text
+              && current.SelectionStart == editor.SelectionStart
+              && current.SelectionEnd == editor.SelectionEnd,
+            "Activation request changed the focused editor")
+        }
+        window.State = WindowState.Minimized
+        let minimizedDeadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency / 4
+        while Stopwatch.GetTimestamp() < minimizedDeadline {
+          window.PumpScheduled(0.0)
+          Thread.Sleep(1)
+        }
+        Require(window.RequestActivation() == WindowActivationResult.Accepted,
+          "Minimized window activation request was not accepted")
+        let deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency / 2
+        while Stopwatch.GetTimestamp() < deadline {
+          window.PumpScheduled(0.0)
+          Thread.Sleep(1)
+        }
+        Console.WriteLine("window-activation: requests=4 editor=preserved synchronous_focus=unchanged"
+          +" observed_focus=" + window.IsFocused.ToString()
+          +" observed_state=" + window.State.ToString())
+      } finally {
+        window.RequestClose()
+        let deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 5
+        while window.IsOpen && Stopwatch.GetTimestamp() < deadline {
+          window.PumpScheduled(0.0)
+          Thread.Sleep(1)
+        }
+        Require(!window.IsOpen, "Activation smoke window did not close")
+        Require(window.RequestActivation() == WindowActivationResult.Closed,
+          "Closed window accepted activation")
+      }
+    }
+  }
+}

--- a/tests/Goo.CoreBehaviorTests/Window/EmbeddedWindowLifecycleTests.cs
+++ b/tests/Goo.CoreBehaviorTests/Window/EmbeddedWindowLifecycleTests.cs
@@ -36,6 +36,37 @@ public sealed class EmbeddedWindowLifecycleTests
     }
 
     [Fact]
+    public void ActivationRequiresOwnerThreadAndDoesNotInventEmbeddedFocus()
+    {
+        var window = new Window { Root = new Root() };
+        Assert.Equal(WindowActivationResult.Closed, window.RequestActivation());
+        using var host = new Host();
+        window.Attach(host);
+        host.RenderFrame(0);
+        var notifications = 0;
+        window.FocusChanged += _ => notifications++;
+        Assert.Equal(WindowActivationResult.Unsupported, window.RequestActivation());
+        Assert.False(window.IsFocused);
+        Assert.Equal(0, notifications);
+        host.SetFocused(true);
+        Assert.Equal(WindowActivationResult.Unsupported, window.RequestActivation());
+        Assert.True(window.IsFocused);
+        Assert.Equal(1, notifications);
+
+        Exception? failure = null;
+        var worker = new Thread(() =>
+        {
+            try { window.RequestActivation(); }
+            catch (Exception error) { failure = error; }
+        });
+        worker.Start();
+        worker.Join();
+        Assert.IsType<InvalidOperationException>(failure);
+        host.Dispose();
+        Assert.Equal(WindowActivationResult.Closed, window.RequestActivation());
+    }
+
+    [Fact]
     public void HostLifecyclePreservesMountedStateAndDispatchUntilFinalClose()
     {
         using var host = new Host();

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,15 @@ Vulkan submission, checks that diagnostic capture reports pending during Busy,
 then releases the queue and verifies three image captures. The CLI test suite
 also checks pending retries and timeout without writing a partial image.
 
+## Window activation
+
+`GOO_WINDOW_ACTIVATION_SMOKE=1` exercises repeated native activation requests,
+preserved editor state, minimized-window requests, and closed-window rejection.
+It checks that requests do not synthesize focus changes. The observed native
+focus and window state are reported separately because compositor policy can
+deny activation without reporting an error. Linux CI runs this with Vulkan
+diagnostics through the headless Wayland wrapper.
+
 ## Timeline completion
 
 Run the shared graphics timeline completion gate with diagnostics:


### PR DESCRIPTION
## Issue

Closes #42. Depends on #45; this PR is based on its embedded-host branch.

## Change

Add `Window.RequestActivation()` to request restoration of a minimized desktop window, raising, and input activation on the owner thread. Report Accepted, Closed, Unsupported, or Failed without synthesizing focus or changing the selected Goo editor. Actual focus remains observable through `IsFocused` and `FocusChanged`.

Use SDL's ordinary activation request and Wayland token/input-serial handling. Desktop policy may deny activation asynchronously without returning an error; Accepted is not confirmation of focus. Embedded hosts return Unsupported. Maximized and fullscreen windows are not explicitly restored.

## Verification

- Release build, strict G# lint, 350 behavior tests, and 12 API/documentation tests passed.
- Native Wayland/Vulkan smoke: four accepted requests, unchanged editor and synchronous focus, and closed-window rejection; zero validation errors or live Vulkan objects after teardown. The compositor left the automated minimized-window request unfocused/minimized, exercising the documented distinction between request acceptance and focus confirmation.
- Added the native activation smoke to Linux CI and regenerated API docs.

## Checklist

- [x] This change stays within the scope agreed in the linked issue.
- [x] I understand the code I submitted and can explain its behavior.
- [x] I updated tests and documentation where needed.
- [x] I understand my PR may be rejected or sent back for rework.
